### PR TITLE
Add logging processing time

### DIFF
--- a/lib/Docs2Vector.d.ts
+++ b/lib/Docs2Vector.d.ts
@@ -1,0 +1,36 @@
+declare class Docs2Vector {
+    private vectorUrl: string;
+    private vectorToken: string;
+    private openAiApiKey: string;
+    private githubToken: string;
+    private namespace: string;
+    private index: any;
+    private embeddings: any;
+    private octokit: any;
+    private textSplitter: any;
+
+    constructor();
+    init(): Promise<void>;
+    reindex(): Promise<void>;
+    search(query: string, limit?: number): Promise<any[]>;
+    addDocument(content: string, metadata: any): Promise<void>;
+
+    private static generateId(content: string): string;
+    private cloneRepository(repoUrl: string): Promise<string>;
+    private findMarkdownFiles(dir: string): Promise<string[]>;
+    private processFile(filePath: string): Promise<Array<{
+        id: string;
+        metadata: {
+            fileName: string;
+            filePath: string;
+            fileType: string;
+            timestamp: number;
+        };
+        vector?: number[];
+        data: string;
+    }>>;
+
+    run(repoUrl: string): Promise<void>;
+}
+
+export default Docs2Vector;

--- a/readme.md
+++ b/readme.md
@@ -125,6 +125,7 @@ import Docs2Vector from "@upstash/docs2vector";
 dotenv.config();
 
 async function main() {
+    console.time('Processing Time');
     try {
         // Step 1: Define the GitHub repository URL
         const githubRepoUrl = 'YOUR_GITHUB_URL';
@@ -141,7 +142,9 @@ async function main() {
         // Print success message
         console.log(`Successfully processed repository: ${githubRepoUrl}`);
         console.log('Vectors stored in Upstash Vector database.');
+        console.timeEnd('Processing Time');
     } catch (error) {
+        console.timeEnd('Processing Time');
         console.error('An error occurred while processing the repository:', error.message);
     }
 }

--- a/script.js
+++ b/script.js
@@ -5,6 +5,7 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 async function main() {
+    console.time('Processing Time');
     try {
         // Step 1: Define the GitHub repository URL
         const githubRepoUrl = 'https://github.com/upstash/docs2vector';
@@ -21,7 +22,9 @@ async function main() {
         // Print success message
         console.log(`Successfully processed repository: ${githubRepoUrl}`);
         console.log('Vectors stored in Upstash Vector database.');
+        console.timeEnd('Processing Time');
     } catch (error) {
+        console.timeEnd('Processing Time');
         console.error('An error occurred while processing the repository:', error.message);
     }
 }


### PR DESCRIPTION
It is helpful to see how long the indexing process takes. If someone wants to create a webhook for indexing, choosing duration limits based on the processing time logs could be useful.